### PR TITLE
feat: Adding logging to provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/Tohaker/omada-go-sdk v0.0.0-20260321154959-0dbb2f0aab1b
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-log v0.10.0
 )
 
 require (
@@ -14,7 +15,6 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -79,6 +80,8 @@ func (p *omadaProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp
 
 // Configure prepares a Omada API client for data sources and resources.
 func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	tflog.Info(ctx, "Configuring Omada client")
+
 	// Retrieve provider data from configuration
 	var config omadaProviderModel
 	diags := req.Config.Get(ctx, &config)
@@ -201,6 +204,14 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "omada_host", host)
+	ctx = tflog.SetField(ctx, "omada_customer_id", customer_id)
+	ctx = tflog.SetField(ctx, "omada_client_id", client_id)
+	ctx = tflog.SetField(ctx, "omada_client_secret", client_secret)
+	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "omada_client_secret")
+
+	tflog.Debug(ctx, "Creating Omada client")
+
 	// Create a new Omada client using the configuration values
 	cfg := omada.NewConfiguration()
 	cfg.Servers = omada.ServerConfigurations{
@@ -240,6 +251,8 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 	resp.DataSourceData = data
 	resp.ResourceData = data
+
+	tflog.Info(ctx, "Configured Omada client", map[string]any{"success": true})
 }
 
 // DataSources defines the data sources implemented in the provider.


### PR DESCRIPTION
## Description

Adds logging, according to the [instructions](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-logging) from Terraform

## Changes to Security Controls

Details passed to the provider are saved to context for logging, but the `omada_client_secret` is explicitly masked to prevent secrets leaking.
