### PR TITLE
feat: Implementing create and read methods on site resource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - "README.md"
   push:
+    branches:
+      - main
     paths-ignore:
       - "README.md"
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Start Provider in Debug Mode",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "args": [
+                "-debug"
+            ],
+            "program": "${workspaceFolder}",
+            "showLog": true
+        }
+    ]
+}

--- a/examples/site/main.tf
+++ b/examples/site/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    omada = {
+      source = "registry.terraform.io/tohaker/omada"
+    }
+  }
+}
+
+provider "omada" {}
+
+resource "omada_site" "example" {
+  name      = "Terraform Example"
+  region    = "United Kingdom"
+  time_zone = "Europe/London"
+  scenario  = "Home"
+
+  device_account_setting = {
+    username = "admin"
+    password = "VeryStr@ngPas5w0rd"
+  }
+}
+
+output "example_sites" {
+  value     = omada_site.example
+  sensitive = true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-omada
 go 1.25.5
 
 require (
-	github.com/Tohaker/omada-go-sdk v0.3.1
+	github.com/Tohaker/omada-go-sdk v0.3.2-0.20260411155512-3039a2b5239e
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/Tohaker/omada-go-sdk v0.3.1 h1:u/tAjsBghETPaEiNb/AZanv6AWqWluNA6SI9Dzu9EZY=
 github.com/Tohaker/omada-go-sdk v0.3.1/go.mod h1:EWK6lekGDxP9bpE439/0jXnWyAGDA7lngLTucT8CoPE=
+github.com/Tohaker/omada-go-sdk v0.3.2-0.20260411141200-a6f0a2538fab h1:3R+v9Ko4nGyp6PR6LnigFSFW2+ASL9AD0DuUBdRO+Co=
+github.com/Tohaker/omada-go-sdk v0.3.2-0.20260411141200-a6f0a2538fab/go.mod h1:EWK6lekGDxP9bpE439/0jXnWyAGDA7lngLTucT8CoPE=
+github.com/Tohaker/omada-go-sdk v0.3.2-0.20260411155512-3039a2b5239e h1:AgnP3BdDwcvoUaZ+W2+/NKihEcbmz7Qz1hQclK0hTDU=
+github.com/Tohaker/omada-go-sdk v0.3.2-0.20260411155512-3039a2b5239e/go.mod h1:EWK6lekGDxP9bpE439/0jXnWyAGDA7lngLTucT8CoPE=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	omada "github.com/Tohaker/omada-go-sdk/omada"
+	"github.com/Tohaker/omada-go-sdk/omada"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -264,5 +264,7 @@ func (p *omadaProvider) DataSources(_ context.Context) []func() datasource.DataS
 
 // Resources defines the resources implemented in the provider.
 func (p *omadaProvider) Resources(_ context.Context) []func() resource.Resource {
-	return nil
+	return []func() resource.Resource{
+		NewSiteResource,
+	}
 }

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -1,0 +1,191 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Tohaker/omada-go-sdk/omada"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource              = &siteResource{}
+	_ resource.ResourceWithConfigure = &siteResource{}
+)
+
+// NewSiteResource is a helper function to simplify the provider implementation.
+func NewSiteResource() resource.Resource {
+	return &siteResource{}
+}
+
+// siteResource is the resource implementation.
+type siteResource struct {
+	client   *omada.APIClient
+	omadacId string
+}
+
+// siteResourceModel maps the resource schema data.
+type siteResourceModel struct {
+	SiteId               types.String                  `tfsdk:"site_id"`
+	Name                 types.String                  `tfsdk:"name"`
+	Type                 types.Int32                   `tfsdk:"type"`
+	Region               types.String                  `tfsdk:"region"`
+	TimeZone             types.String                  `tfsdk:"time_zone"`
+	Scenario             types.String                  `tfsdk:"scenario"`
+	TagIDs               []types.String                `tfsdk:"tag_ids"`
+	Longitude            types.Float64                 `tfsdk:"longitude"`
+	Latitude             types.Float64                 `tfsdk:"latitude"`
+	Address              types.String                  `tfsdk:"address"`
+	DeviceAccountSetting siteDeviceAccountSettingModel `tfsdk:"device_account_setting"`
+	SupportES            types.Bool                    `tfsdk:"support_es"`
+	SupportL2            types.Bool                    `tfsdk:"support_l2"`
+}
+
+// siteDeviceAccountSettingModel maps device account settings data.
+type siteDeviceAccountSettingModel struct {
+	Username types.String `tfsdk:"username"`
+	Password types.String `tfsdk:"password"`
+}
+
+// Configure adds the provider configured client to the resource.
+func (d *siteResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Add a nil check when handling ProviderData because Terraform
+	// sets that data after it calls the ConfigureProvider RPC.
+	if req.ProviderData == nil {
+		return
+	}
+
+	data, ok := req.ProviderData.(*providerData)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *omada.APIClient, got %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = data.Client
+	d.omadacId = data.OmadacId
+}
+
+// Metadata returns the resource type name.
+func (r *siteResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_site"
+}
+
+// Schema defines the schema for the resource.
+func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"site_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"type": schema.Int32Attribute{},
+			"region": schema.StringAttribute{
+				Required: true,
+			},
+			"time_zone": schema.StringAttribute{
+				Required: true,
+			},
+			"scenario": schema.StringAttribute{
+				Required: true,
+			},
+			"tag_ids": schema.ListAttribute{
+				ElementType: types.StringType,
+			},
+			"longitude": schema.Float64Attribute{},
+			"latitude":  schema.Float64Attribute{},
+			"address":   schema.StringAttribute{},
+			"device_account_setting": schema.SingleNestedAttribute{
+				Required: true,
+				Attributes: map[string]schema.Attribute{
+					"username": schema.StringAttribute{
+						Required: true,
+					},
+					"password": schema.StringAttribute{
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+			},
+			"support_es": schema.BoolAttribute{},
+			"support_l2": schema.BoolAttribute{},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Retrieve values from plan
+	var plan siteResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Generate API request body from plan
+	var siteEntity omada.CreateSiteEntity
+	siteEntity.Name = plan.Name.ValueString()
+	siteEntity.Type = plan.Type.ValueInt32Pointer()
+	siteEntity.Region = plan.Region.ValueString()
+	siteEntity.TimeZone = plan.TimeZone.ValueString()
+	siteEntity.Scenario = plan.Scenario.ValueString()
+	siteEntity.Longitude = plan.Longitude.ValueFloat64Pointer()
+	siteEntity.Latitude = plan.Latitude.ValueFloat64Pointer()
+	siteEntity.Address = plan.Address.ValueStringPointer()
+	siteEntity.DeviceAccountSetting = omada.DeviceAccountSettingOpenApiVO{
+		Username: plan.DeviceAccountSetting.Username.ValueString(),
+		Password: plan.DeviceAccountSetting.Password.ValueString(),
+	}
+	siteEntity.SupportES = plan.SupportES.ValueBoolPointer()
+	siteEntity.SupportL2 = plan.SupportL2.ValueBoolPointer()
+
+	var tagIds []string
+	for _, tagId := range plan.TagIDs {
+		tagIds = append(tagIds, tagId.ValueString())
+	}
+
+	siteEntity.TagIds = tagIds
+
+	// Create new site
+	site, _, err := r.client.SiteAPI.CreateNewSite(ctx, r.omadacId).CreateSiteEntity(siteEntity).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating site",
+			"Could not create site, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// Map response body to schema
+	if siteId, ok := site.Result["siteId"].(string); ok {
+		plan.SiteId = types.StringValue(siteId)
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *siteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *siteResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *siteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -166,9 +166,7 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Map response body to schema
-	if siteId, ok := site.Result["siteId"].(string); ok {
-		plan.SiteId = types.StringValue(siteId)
-	}
+	plan.SiteId = types.StringPointerValue(site.Result.SiteId)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -89,6 +89,7 @@ func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"type": schema.Int32Attribute{
 				Optional: true,
+				Computed: true,
 			},
 			"region": schema.StringAttribute{
 				Required: true,
@@ -126,9 +127,11 @@ func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"support_es": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
 			},
 			"support_l2": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}
@@ -188,6 +191,19 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// Map response body to schema
 	plan.SiteId = types.StringPointerValue(site.Result.SiteId)
+
+	updatedSite, _, err := r.client.SiteAPI.GetSiteEntity(ctx, r.omadacId, plan.SiteId.ValueString()).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading Site Entry",
+			"Could not read Omada site ID "+plan.SiteId.ValueString()+": "+err.Error(),
+		)
+	}
+
+	// Ensure non-nullable properties without are set to their computed value in the plan
+	plan.Type = types.Int32PointerValue(updatedSite.Result.Type)
+	plan.SupportES = types.BoolPointerValue(updatedSite.Result.SupportES)
+	plan.SupportL2 = types.BoolPointerValue(updatedSite.Result.SupportL2)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -87,7 +87,9 @@ func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"name": schema.StringAttribute{
 				Required: true,
 			},
-			"type": schema.Int32Attribute{},
+			"type": schema.Int32Attribute{
+				Optional: true,
+			},
 			"region": schema.StringAttribute{
 				Required: true,
 			},
@@ -99,10 +101,17 @@ func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"tag_ids": schema.ListAttribute{
 				ElementType: types.StringType,
+				Optional:    true,
 			},
-			"longitude": schema.Float64Attribute{},
-			"latitude":  schema.Float64Attribute{},
-			"address":   schema.StringAttribute{},
+			"longitude": schema.Float64Attribute{
+				Optional: true,
+			},
+			"latitude": schema.Float64Attribute{
+				Optional: true,
+			},
+			"address": schema.StringAttribute{
+				Optional: true,
+			},
 			"device_account_setting": schema.SingleNestedAttribute{
 				Required: true,
 				Attributes: map[string]schema.Attribute{
@@ -115,8 +124,12 @@ func (r *siteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 					},
 				},
 			},
-			"support_es": schema.BoolAttribute{},
-			"support_l2": schema.BoolAttribute{},
+			"support_es": schema.BoolAttribute{
+				Optional: true,
+			},
+			"support_l2": schema.BoolAttribute{
+				Optional: true,
+			},
 		},
 	}
 }
@@ -165,6 +178,14 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	if *site.ErrorCode != 0 {
+		resp.Diagnostics.AddError(
+			"Error creating site",
+			fmt.Sprintf("Could not create site, error code %d: %s", *site.ErrorCode, *site.Msg),
+		)
+		return
+	}
+
 	// Map response body to schema
 	plan.SiteId = types.StringPointerValue(site.Result.SiteId)
 
@@ -178,6 +199,49 @@ func (r *siteResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 // Read refreshes the Terraform state with the latest data.
 func (r *siteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Get current state
+	var state siteResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get refreshed site from API
+	site, _, err := r.client.SiteAPI.GetSiteEntity(ctx, r.omadacId, state.SiteId.ValueString()).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading Site Entity",
+			"Could not read Omada site ID "+state.SiteId.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	// Overwrite site with refreshed state
+	state.Name = types.StringPointerValue(site.Result.Name)
+	state.Type = types.Int32PointerValue(site.Result.Type)
+	state.Region = types.StringPointerValue(site.Result.Region)
+	state.TimeZone = types.StringPointerValue(site.Result.TimeZone)
+	state.Scenario = types.StringPointerValue(site.Result.Scenario)
+	state.Longitude = types.Float64PointerValue(site.Result.Longitude)
+	state.Latitude = types.Float64PointerValue(site.Result.Latitude)
+	state.Address = types.StringPointerValue(site.Result.Address)
+	state.SupportES = types.BoolPointerValue(site.Result.SupportES)
+	state.SupportL2 = types.BoolPointerValue(site.Result.SupportL2)
+
+	var TagIDs []types.String
+	for _, tagId := range site.Result.TagIds {
+		TagIDs = append(TagIDs, types.StringValue(tagId))
+	}
+
+	state.TagIDs = TagIDs
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Update updates the resource and sets the updated Terraform state on success.


### PR DESCRIPTION
## Description

Following https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-resource-create#providers-plugin-framework-resource-create, the `site` resource can be created and imported with the `Create` and `Read` methods implemented.
