### PR TITLE
fix: Release build one at a time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release --clean
+          args: release --clean --parallelism=1
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+FIXES:
+- Running only 1 task in parallel during release 
+
 ## 0.1.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## 0.1.0 (Unreleased)
+## 0.1.0
 
 FEATURES:
+- Added `site` resource
+- Added `sites` data source


### PR DESCRIPTION
## Description

Attempts to fix the release workflow by running only one build at a time, and not starving the container of resources.