### PR TITLE
security: GH-31 Configuring TLS via Provider Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+## 0.2.0
+
+FEATURES:
+- Added `tls_skip_verify` option to provider config.
+
 ## 0.1.2
 
+FEATURES:
 - Updating documentation. No functional changes.
 
 ## 0.1.1

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ For authentication, the provider requires you to supply the following informatio
 - Host
 - Client ID
 - Client Secret
-- Customer or MSP ID (also referred to as the Omada ID)
+- Controller ID (also referred to as the Omada ID)
 
 For detailed instructions on how to obtain these from your Software Controller, [see here](https://support.omadanetworks.com/uk/document/109315#_Toc212122902).
 
@@ -27,9 +27,11 @@ You may also choose to set these to the following environment variables respecti
 - `OMADA_CLIENT_ID`
 - `OMADA_CLIENT_SECRET`
 - `OMADA_CONTROLLER_ID`
+- `OMADA_TLS_SKIP_VERIFY`
 
 -> If you are self-hosting your Software Controller, the host must be resolvable from wherever your Terraform configuration is deployed. 
-For example, in your local network you may set your host to `https://192.168.0.10:8043`
+For example, in your local network you may set your host to `https://192.168.0.10:8043`. 
+You may also need to set `tls_skip_verify` to `true` if your Software Controller has self-signed certificates. However this is not advisable if you will be deploying the configuration to a production environment. 
 
 ## Example Usage
 
@@ -57,6 +59,9 @@ provider "omada" {
   # Alternatively, omit this field and supply it securely 
   # with the OMADA_CLIENT_SECRET environment variable
   client_secret = var.client_secret
+
+  # Explicitly set the TLS verification setting
+  tls_skip_verify = false
 }
 ```
 
@@ -69,3 +74,5 @@ provider "omada" {
 - `client_secret` (String, Sensitive) Client Secret for the Omada Controller Application. May also be provided via `OMADA_CLIENT_SECRET` environment variable.
 - `controller_id` (String) Unique ID assigned to the Omada Controller. May also be provided via `OMADA_CONTROLLER_ID` environment variable.
 - `host` (String) URI for the Omada Controller API. May also be provided via `OMADA_HOST` environment variable.
+- `tls_skip_verify` (Boolean) When set to true, accepts any certificate presented by the server and any host name in that certificate.
+				**It is unadvisable to use this in a production environment, as it makes the provider susceptible to man-in-the-middle attacks.**

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -21,4 +21,7 @@ provider "omada" {
   # Alternatively, omit this field and supply it securely 
   # with the OMADA_CLIENT_SECRET environment variable
   client_secret = var.client_secret
+
+  # Explicitly set the TLS verification setting
+  tls_skip_verify = false
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -21,6 +21,18 @@ provider "omada" {
 `, host, TestControllerID)
 }
 
+func providerConfigWithTLSSkipVerify(host string, tlsSkipVerify bool) string {
+	return fmt.Sprintf(`
+provider "omada" {
+  host            = %q
+  controller_id   = %q
+  client_id       = "test-client-id"
+  client_secret   = "test-client-secret"
+  tls_skip_verify = %t
+}
+`, host, TestControllerID, tlsSkipVerify)
+}
+
 // TestServer is a configurable httptest-backed Omada API stand-in.
 //
 // TokenHandler is invoked for POST /openapi/authorize/token requests. Tests may
@@ -61,4 +73,31 @@ func NewTestServer(t *testing.T) *TestServer {
 	ts.URL = server.URL
 	ts.ProviderConfig = providerConfig(server.URL)
 	return ts
+}
+
+// NewTLSTestServer is like NewTestServer but serves HTTPS using httptest's
+// auto-generated self-signed certificate. Use it to exercise the provider's
+// tls_skip_verify behavior. The default ProviderConfig sets
+// tls_skip_verify = true so the test server is reachable; use
+// ProviderConfigWithTLSSkipVerify(false) to assert verification failures.
+func NewTLSTestServer(t *testing.T) *TestServer {
+	t.Helper()
+	ts := &TestServer{
+		Mux:          http.NewServeMux(),
+		TokenHandler: defaultTokenHandler,
+	}
+	ts.Mux.HandleFunc("POST /openapi/authorize/token", func(w http.ResponseWriter, r *http.Request) {
+		ts.TokenHandler(w, r)
+	})
+	server := httptest.NewTLSServer(ts.Mux)
+	t.Cleanup(server.Close)
+	ts.URL = server.URL
+	ts.ProviderConfig = providerConfigWithTLSSkipVerify(server.URL, true)
+	return ts
+}
+
+// ProviderConfigWithTLSSkipVerify returns a provider configuration block for
+// this test server with tls_skip_verify set to the given value.
+func (ts *TestServer) ProviderConfigWithTLSSkipVerify(tlsSkipVerify bool) string {
+	return providerConfigWithTLSSkipVerify(ts.URL, tlsSkipVerify)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"os"
+	"strconv"
 	"terraform-provider-omada/internal/client"
 	"terraform-provider-omada/internal/service/site"
 
@@ -41,10 +42,11 @@ type omadaProvider struct {
 
 // omadaProviderModel maps provider schema data to a Go type.
 type omadaProviderModel struct {
-	Host         types.String `tfsdk:"host"`
-	ControllerId types.String `tfsdk:"controller_id"`
-	ClientId     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
+	Host          types.String `tfsdk:"host"`
+	ControllerId  types.String `tfsdk:"controller_id"`
+	ClientId      types.String `tfsdk:"client_id"`
+	ClientSecret  types.String `tfsdk:"client_secret"`
+	TlsSkipVerify types.Bool   `tfsdk:"tls_skip_verify"`
 }
 
 // Metadata returns the provider type name.
@@ -74,6 +76,11 @@ func (p *omadaProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp
 				Description: "Client Secret for the Omada Controller Application. May also be provided via `OMADA_CLIENT_SECRET` environment variable.",
 				Optional:    true,
 				Sensitive:   true,
+			},
+			"tls_skip_verify": schema.BoolAttribute{
+				Description: `When set to true, accepts any certificate presented by the server and any host name in that certificate.
+				**It is unadvisable to use this in a production environment, as it makes the provider susceptible to man-in-the-middle attacks.**`,
+				Optional: true,
 			},
 		},
 	}
@@ -130,6 +137,15 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		)
 	}
 
+	if config.TlsSkipVerify.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("tls_skip_verify"),
+			"Unknown value for tls_skip_verify",
+			"The provider cannot create the Omada API client as there is an unknown configuration value for the TLS verification. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the OMADA_TLS_SKIP_VERIFY environment variable.",
+		)
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -141,6 +157,9 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 	controller_id := os.Getenv("OMADA_CONTROLLER_ID")
 	client_id := os.Getenv("OMADA_CLIENT_ID")
 	client_secret := os.Getenv("OMADA_CLIENT_SECRET")
+
+	// Read and parse the env variable as a boolean.
+	tls_skip_verify, parse_err := strconv.ParseBool(os.Getenv("OMADA_TLS_SKIP_VERIFY"))
 
 	if !config.Host.IsNull() {
 		host = config.Host.ValueString()
@@ -156,6 +175,10 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 	if !config.ClientSecret.IsNull() {
 		client_secret = config.ClientSecret.ValueString()
+	}
+
+	if !config.TlsSkipVerify.IsNull() {
+		tls_skip_verify = config.TlsSkipVerify.ValueBool()
 	}
 
 	// If any of the expected configurations are missing, return
@@ -201,6 +224,11 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		)
 	}
 
+	// We don't need to add an error, we will just consider the tls_skip_verify as false
+	if parse_err != nil {
+		tls_skip_verify = false
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -215,8 +243,7 @@ func (p *omadaProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			// TODO: Remove this when testing environment has SSL certification configured
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: tls_skip_verify},
 		},
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"regexp"
 	"terraform-provider-omada/internal/acctest"
@@ -16,19 +17,22 @@ var ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, erro
 	"omada": providerserver.NewProtocol6WithError(New("test")()),
 }
 
-func Test_Provider_NoInlineConfig(t *testing.T) {
+func Test_Provider_NoHost(t *testing.T) {
 	// Ensure env-var fallbacks don't satisfy the provider.
 	t.Setenv("OMADA_HOST", "")
 	t.Setenv("OMADA_CONTROLLER_ID", "")
 	t.Setenv("OMADA_CLIENT_ID", "")
 	t.Setenv("OMADA_CLIENT_SECRET", "")
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
 
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `
-					provider "omada" {}
+					provider "omada" {
+						tls_skip_verify = true
+					}
 
 					data "omada_sites" "test" {}
 				`,
@@ -44,6 +48,7 @@ func Test_Provider_NoControllerId(t *testing.T) {
 	t.Setenv("OMADA_CONTROLLER_ID", "")
 	t.Setenv("OMADA_CLIENT_ID", "")
 	t.Setenv("OMADA_CLIENT_SECRET", "")
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
 
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -51,7 +56,8 @@ func Test_Provider_NoControllerId(t *testing.T) {
 			{
 				Config: `
 					provider "omada" {
-						host = "https://example.com"
+						host            = "https://example.com"
+						tls_skip_verify = true
 					}
 
 					data "omada_sites" "test" {}
@@ -68,6 +74,7 @@ func Test_Provider_NoClientId(t *testing.T) {
 	t.Setenv("OMADA_CONTROLLER_ID", "")
 	t.Setenv("OMADA_CLIENT_ID", "")
 	t.Setenv("OMADA_CLIENT_SECRET", "")
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
 
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -75,8 +82,9 @@ func Test_Provider_NoClientId(t *testing.T) {
 			{
 				Config: `
 					provider "omada" {
-						host 		  = "https://example.com"
-						controller_id = "test-controller-id"
+						host 		    = "https://example.com"
+						controller_id   = "test-controller-id"
+						tls_skip_verify = true
 					}
 
 					data "omada_sites" "test" {}
@@ -93,6 +101,7 @@ func Test_Provider_NoClientSecret(t *testing.T) {
 	t.Setenv("OMADA_CONTROLLER_ID", "")
 	t.Setenv("OMADA_CLIENT_ID", "")
 	t.Setenv("OMADA_CLIENT_SECRET", "")
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
 
 	resource.UnitTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -100,9 +109,10 @@ func Test_Provider_NoClientSecret(t *testing.T) {
 			{
 				Config: `
 					provider "omada" {
-						host 		  = "https://example.com"
-						controller_id = "test-controller-id"
-						client_id	  = "test-client-id"
+						host 		    = "https://example.com"
+						controller_id   = "test-controller-id"
+						client_id	    = "test-client-id"
+						tls_skip_verify = true
 					}
 
 					data "omada_sites" "test" {}
@@ -129,6 +139,86 @@ func TestAcc_Provider_ClientCreationFailed(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      ts.ProviderConfig + `data "omada_sites" "test" {}`,
+				ExpectError: regexp.MustCompile("Unable to create Omada API Client"),
+			},
+		},
+	})
+}
+
+// Ensures that when tls_skip_verify is false the provider refuses a self-signed certificate.
+func TestAcc_Provider_TLSSkipVerify_False_RejectsSelfSigned(t *testing.T) {
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
+
+	ts := acctest.NewTLSTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      ts.ProviderConfigWithTLSSkipVerify(false) + `data "omada_sites" "test" {}`,
+				ExpectError: regexp.MustCompile(`(?i)x509|certificate signed by unknown authority|tls`),
+			},
+		},
+	})
+}
+
+// TestAcc_Provider_TLSSkipVerify_True_AcceptsSelfSigned ensures that when
+// tls_skip_verify is true the provider successfully completes the TLS
+// handshake against a self-signed certificate. We force a known controller-
+// side error so the test asserts the request reached the server (i.e. the
+// handshake succeeded) without needing to stub the entire API surface.
+func TestAcc_Provider_TLSSkipVerify_True_AcceptsSelfSigned(t *testing.T) {
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "")
+
+	ts := acctest.NewTLSTestServer(t)
+	ts.TokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errorCode": -1,
+			"msg":       "No access token found",
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      ts.ProviderConfig + `data "omada_sites" "test" {}`,
+				ExpectError: regexp.MustCompile("Unable to create Omada API Client"),
+			},
+		},
+	})
+}
+
+// TestAcc_Provider_TLSSkipVerify_EnvVar ensures the OMADA_TLS_SKIP_VERIFY env
+// var is honored when the attribute is omitted from configuration.
+func TestAcc_Provider_TLSSkipVerify_EnvVar(t *testing.T) {
+	t.Setenv("OMADA_TLS_SKIP_VERIFY", "true")
+
+	ts := acctest.NewTLSTestServer(t)
+	ts.TokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errorCode": -1,
+			"msg":       "No access token found",
+		})
+	}
+
+	// Build a provider config that omits tls_skip_verify so the env var is used.
+	cfg := fmt.Sprintf(`
+provider "omada" {
+  host          = %q
+  controller_id = %q
+  client_id     = "test-client-id"
+  client_secret = "test-client-secret"
+}
+`, ts.URL, acctest.TestControllerID)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg + `data "omada_sites" "test" {}`,
 				ExpectError: regexp.MustCompile("Unable to create Omada API Client"),
 			},
 		},

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,7 +17,7 @@ For authentication, the provider requires you to supply the following informatio
 - Host
 - Client ID
 - Client Secret
-- Customer or MSP ID (also referred to as the Omada ID)
+- Controller ID (also referred to as the Omada ID)
 
 For detailed instructions on how to obtain these from your Software Controller, [see here](https://support.omadanetworks.com/uk/document/109315#_Toc212122902).
 
@@ -27,9 +27,11 @@ You may also choose to set these to the following environment variables respecti
 - `OMADA_CLIENT_ID`
 - `OMADA_CLIENT_SECRET`
 - `OMADA_CONTROLLER_ID`
+- `OMADA_TLS_SKIP_VERIFY`
 
 -> If you are self-hosting your Software Controller, the host must be resolvable from wherever your Terraform configuration is deployed. 
-For example, in your local network you may set your host to `https://192.168.0.10:8043`
+For example, in your local network you may set your host to `https://192.168.0.10:8043`. 
+You may also need to set `tls_skip_verify` to `true` if your Software Controller has self-signed certificates. However this is not advisable if you will be deploying the configuration to a production environment. 
 
 ## Example Usage
 


### PR DESCRIPTION
## Related Issue

Fixes #31

## Description

Added `tls_skip_verify` option to the provider to enable users to configure the provider to be able to communicate with self-hosted Omada Software Controllers
